### PR TITLE
Fix the bug for reading custom messages from Minecraft

### DIFF
--- a/src/MCreatorLink.cpp
+++ b/src/MCreatorLink.cpp
@@ -27,7 +27,7 @@ void MCreatorLinkImpl::setup(Stream &serial_ref, String _deviceName) {
   }
 }
 
-void MCreatorLinkImpl::setListener(void (*event_ptr)(String command, String data)) {
+void MCreatorLinkImpl::setListener(void (*event_ptr)(String command)) {
   event = event_ptr;
 }
 
@@ -79,7 +79,7 @@ void MCreatorLinkImpl::loop() {
         analogWrite(pin, val);
       }
     } else if (command.equals("msg")) {
-      event(command, data);
+      event(command);
     }
   }
   

--- a/src/MCreatorLink.h
+++ b/src/MCreatorLink.h
@@ -28,7 +28,7 @@ class MCreatorLinkImpl
     int inputReadRefreshRate = 20;
     bool pollInputs = false;
     unsigned long lastInputPollMillis = 0;
-    void (*event)(String command, String data);
+    void (*event)(String command);
     String deviceName;
   public:
 
@@ -56,7 +56,7 @@ class MCreatorLinkImpl
     /*
     Here the listener function for the inbound messages can be set. See examples for more info.
     */
-    void setListener(void (*event)(String command, String data));
+    void setListener(void (*event)(String command));
 
     /*
     Function to set the refresh rate of the input checking.


### PR DESCRIPTION
I deleted code that was a reason why Arduino couldn't read messages properly.